### PR TITLE
[김현수] 프론트 7주차 과제 제출

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,10 @@ textarea {
   padding: 10px;
 }
 
+.Editor .editor-lucky {
+  background-color: rgb(159, 221, 255);
+}
+
 .Editor button {
   width: 200px;
   padding: 10px;
@@ -55,7 +59,7 @@ textarea {
 }
 
 .Item .done {
-  color: gray;
+  color: rgb(189, 189, 189);
 }
 
 .Item button {

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,8 @@ import List from "./List";
 import React, { useState, useRef, useEffect } from "react";
 import { Routes, Route, Link } from "react-router-dom";
 import Luck from "./Luck";
+import { useCallback } from "react";
+import Test from "./Test";
 
 function App() {
   const [data, setData] = useState(() => {
@@ -20,34 +22,34 @@ function App() {
   const dataId = useRef(0);
 
   //새로운 일기를 추가하는 함수
-  const onCreate = (content) => {
+  const onCreate = useCallback((content) => {
     const newItem = {
       //새로운 todo 객체 생성
       content,
-      id: dataId.current, // 현재 상태값
+      id: dataId.current++, // 현재 상태값
       isDone: false,
     };
-    setData([...data, newItem]);
-  };
 
-  const onDelete = (targetId) => {
-    const newList = data.filter((it) => it.id !== targetId);
-    setData(newList);
-  };
+    setData((data) => [...data, newItem]);
+  }, []);
 
-  const onEdit = (targetId, newContent) => {
-    setData(
+  const onDelete = useCallback((targetId) => {
+    setData((data) => data.filter((it) => it.id !== targetId));
+  }, []);
+
+  const onEdit = useCallback((targetId, newContent) => {
+    setData((data) =>
       data.map((it) =>
         it.id === targetId ? { ...it, content: newContent } : it
       )
     );
-  };
+  }, []);
 
-  const onToggle = (targetId) => {
-    setData(
+  const onToggle = useCallback((targetId) => {
+    setData((data) =>
       data.map((it) => (it.id === targetId ? { ...it, isDone: true } : it))
     );
-  };
+  }, []);
 
   return (
     <div className="App">
@@ -55,7 +57,9 @@ function App() {
         <Route
           path="/"
           element={[
+            <Test />,
             <Editor onCreate={onCreate} />,
+
             <List
               onDelete={onDelete}
               onEdit={onEdit}

--- a/src/Editor.js
+++ b/src/Editor.js
@@ -1,8 +1,13 @@
 import React, { useState, useRef } from "react";
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 
 const Editor = ({ onCreate }) => {
   const [content, setContent] = useState("");
+
+  useEffect(() => {
+    console.log("에디터 업데이트");
+  }, []);
 
   const contentInput = useRef();
   //작성하는 곳에 접근 할 수 있다.
@@ -17,7 +22,7 @@ const Editor = ({ onCreate }) => {
       return;
     }
     onCreate(content);
-    alert("저장 성공");
+    // alert("저장 성공");
     setContent("");
   };
 
@@ -32,11 +37,11 @@ const Editor = ({ onCreate }) => {
         <button onClick={handleSubmit}>저장하기</button>
 
         <Link to="/luck">
-          <button>Luck</button>
+          <button className="editor-lucky">Luck</button>
         </Link>
       </div>
     </div>
   );
 };
 
-export default Editor;
+export default React.memo(Editor);

--- a/src/Item.js
+++ b/src/Item.js
@@ -9,7 +9,7 @@ const Item = ({ content, id, onDelete, onEdit, onToggle, item }) => {
 
   const handleRemove = () => {
     console.log(id);
-    if (window.confirm(`${id + 1} 번째 일기를 정말 삭제하시겠습니까?`)) {
+    if (window.confirm(`${id + 1} 번째 리스트를 정말 삭제하시겠습니까?`)) {
       onDelete(id);
     }
   };
@@ -25,7 +25,7 @@ const Item = ({ content, id, onDelete, onEdit, onToggle, item }) => {
       return;
     }
 
-    if (window.confirm(`${id + 1} 번째 일기를 수정하시겠습니까?`)) {
+    if (window.confirm(`${id + 1} 번째 리스트를 수정하시겠습니까?`)) {
       onEdit(id, localContent);
       toggleIsEdit();
     }
@@ -63,8 +63,8 @@ const Item = ({ content, id, onDelete, onEdit, onToggle, item }) => {
       ) : (
         <>
           {" "}
-          <button onClick={handleRemove}>삭제하기</button>
-          <button onClick={toggleIsEdit}>수정하기</button>
+          <button onClick={handleRemove}>삭제</button>
+          <button onClick={toggleIsEdit}>수정</button>
         </>
       )}
 
@@ -73,4 +73,4 @@ const Item = ({ content, id, onDelete, onEdit, onToggle, item }) => {
   );
 };
 
-export default Item;
+export default React.memo(Item);

--- a/src/Luck.js
+++ b/src/Luck.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 const Luck = () => {
   const [luck, setLuck] = useState("오늘의 운세는?");
-  const [song, setSong] = useState("오늘의 노래는?");
+  const [song, setSong] = useState("");
   const randomLuck = () => {
     const ranNum = Math.floor(Math.random() * 5);
     setLuck(luckybox[ranNum]);
@@ -148,11 +148,11 @@ const Luck = () => {
         </div>
 
         <Link to="/">
-          <button> Back to TodoList</button>
+          <button> 되돌아가기</button>
         </Link>
       </div>
     </div>
   );
 };
 
-export default Luck;
+export default React.memo(Luck);

--- a/src/Test.js
+++ b/src/Test.js
@@ -1,0 +1,40 @@
+import React, { useState } from "react";
+import { useEffect } from "react";
+
+const TextView = React.memo(({ text }) => {
+  useEffect(() => {
+    console.log(`업데이트 : ${text}`);
+  });
+  return <div>{text}</div>;
+});
+
+const CountView = React.memo(({ count }) => {
+  console.log(`업데이트 : ${count}`);
+  return <div>{count}</div>;
+});
+
+const Test = () => {
+  const [count, setCount] = useState(1);
+  const [text, setText] = useState("");
+  return (
+    <div>
+      <div>
+        <h2>Count</h2>
+        <CountView count={count} />
+        <button onClick={() => setCount(count + 1)}>+</button>
+      </div>
+      <div>
+        <h2>Text</h2>
+        <TextView text={text} />
+        <input
+          value={text}
+          onChange={(e) => {
+            setText(e.target.value);
+          }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default Test;


### PR DESCRIPTION
### 결과물 소개
1. 투두 리스트와 관계없는 count와 text기능 최적화
2. 투두 리스트 최적화

### 상세 설명
React.memo를 사용하여 Test.js 를 최적화 시켰습니다.
기존에는 Counter만 바뀌어도 text도 리랜더 되었는데 최적화 후에는 
하나의 state만 바뀌면 해당하는 곳만 랜더링됩니다. 
useEffect를 사용하여 확인할 수 있었습니다. 

onCreate 함수를 useCallback으로 최적화 시켜서 app.js가 렌더링 되거나 새로운 리스트가 추가되어도
editor가 불필요하게 리랜더 되지 않도록 만들었습니다. 

또한 List.js에서도 투두항목들이 지속적으로 불필요한 리랜더가 일어나서 onDelete,
onEdit, onToggle에 모두 useCallback을 사용하여 Editor의 불필요한 랜더링을 줄었습니다.

### 결과물 배포 링크
[efub3-frontend-assignment-2-eight.vercel.app](https://efub3-frontend-assignment-2-eight.vercel.app/)

### 결과물
useEffect를 사용하여 랜더링 될 때 마다 콘솔에 출력되도록 하였습니다.
![7주차 과제 사진1](https://github.com/EFUB/efub3-frontend-assignment-2/assets/105619531/3f92f5ef-4877-4d59-8356-7268b7d3e36d)


