### PR TITLE
[이주희] 프론트 7주차 과제 제출

### DIFF
--- a/todo/src/App.js
+++ b/todo/src/App.js
@@ -17,9 +17,17 @@ function App() {
     localStorage.setItem("localTodo", JSON.stringify(todo));
   }, [todo]);
 
+  const [test, setTest] = useState(0);
+
+  const Test = () => {
+    setTest(test + 1);
+  };
+
   return (
     <>
       <Head />
+      <button onClick={Test}>test</button>
+      {test}
       <Template>
         <NavBar todoList={todo} />
         <Routes>

--- a/todo/src/components/AddTodo.js
+++ b/todo/src/components/AddTodo.js
@@ -1,6 +1,7 @@
 import styled, { css } from "styled-components";
 import { useState } from "react";
 import { ReactComponent as Plus } from "../images/plus.svg";
+import React from "react";
 
 const AddTodo = ({ todoList, setTodoList }) => {
   const [text, setText] = useState("");
@@ -132,4 +133,4 @@ const Input = styled.input`
   color: #565656;
 `;
 
-export default AddTodo;
+export default React.memo(AddTodo);

--- a/todo/src/components/Head.js
+++ b/todo/src/components/Head.js
@@ -1,6 +1,7 @@
 import styled from "styled-components";
 import { ReactComponent as LogoIcon } from "../images/logo.svg";
 import { Link } from "react-router-dom";
+import React from "react";
 
 function Head() {
   return (
@@ -39,4 +40,4 @@ const H1 = styled.h1`
   font-size: 20px;
 `;
 
-export default Head;
+export default React.memo(Head);

--- a/todo/src/components/NavBar.js
+++ b/todo/src/components/NavBar.js
@@ -7,7 +7,7 @@ import { ReactComponent as ListIcon } from "../images/toc.svg";
 import { ReactComponent as Search } from "../images/search.svg";
 import { ReactComponent as BoardIcon } from "../images/board.svg";
 import { Link } from "react-router-dom";
-import { useState } from "react";
+import React, { useMemo } from "react";
 
 function NavBar({ todoList }) {
   const LinkStyle = {
@@ -16,6 +16,15 @@ function NavBar({ todoList }) {
     marginBottom: "10px",
     color: "#565656",
   };
+
+  const counts = useMemo(
+    () => ({
+      1: todoList.filter((item) => item.priority === 1).length,
+      2: todoList.filter((item) => item.priority === 2).length,
+      3: todoList.filter((item) => item.priority === 3).length,
+    }),
+    [todoList]
+  );
 
   return (
     <SideBarBlock>
@@ -53,21 +62,21 @@ function NavBar({ todoList }) {
           <Red />
           <Btn>Priority 1</Btn>
         </Container>
-        <Span>{todoList.filter((item) => item.priority === 1).length}</Span>
+        <Span>{counts[1]}</Span>
       </Div>
       <Div>
         <Container>
           <Yellow />
           <Btn>Priority 2</Btn>
         </Container>
-        <Span>{todoList.filter((item) => item.priority === 2).length}</Span>
+        <Span>{counts[2]}</Span>
       </Div>
       <Div>
         <Container>
           <Green />
           <Btn>Priority 3</Btn>
         </Container>
-        <Span>{todoList.filter((item) => item.priority === 3).length}</Span>
+        <Span>{counts[3]}</Span>
       </Div>
     </SideBarBlock>
   );
@@ -166,4 +175,4 @@ const SideBarBlock = styled.div`
   color: #565656;
 `;
 
-export default NavBar;
+export default React.memo(NavBar);

--- a/todo/src/components/TodoBoard.js
+++ b/todo/src/components/TodoBoard.js
@@ -10,6 +10,7 @@ const getItems = (todoList) => {
   return todoList.map((item, i) => ({
     id: `item-${i}-${item.id}`,
     content: item.text,
+    done: item.done,
   }));
 };
 
@@ -95,9 +96,11 @@ const TodoBoard = ({ todoList, setTodoList }) => {
     if (!destination) {
       return;
     }
-    const sInd = +source.droppableId;
-    const dInd = +destination.droppableId;
+    const sInd = +source.droppableId; // 원래 열 ex. 0
+    const dInd = +destination.droppableId; // 이동할 열 ex. 1
 
+    // 원래 열과 이동할 열이 같은 경우 행 정렬(redorder), 다른 경우 열 이동(move)
+    // 열 간에 이동하면 done 속성 반대로 ! 만들기(todoList에 반영하기)
     if (sInd === dInd) {
       const items = reorder(state[sInd], source.index, destination.index);
       const newState = [...state];
@@ -217,4 +220,4 @@ const Status = styled.span`
   display: flex;
 `;
 
-export default TodoBoard;
+export default React.memo(TodoBoard);

--- a/todo/src/components/TodoHead.js
+++ b/todo/src/components/TodoHead.js
@@ -46,4 +46,4 @@ const H3 = styled.h3`
   margin-bottom: 30px;
 `;
 
-export default TodoHead;
+export default React.memo(TodoHead);

--- a/todo/src/components/TodoItem.js
+++ b/todo/src/components/TodoItem.js
@@ -8,6 +8,7 @@ import { ReactComponent as CheckP0 } from "../images/check.svg";
 import { ReactComponent as CheckP1 } from "../images/red_check.svg";
 import { ReactComponent as CheckP2 } from "../images/yellow_check.svg";
 import { ReactComponent as CheckP3 } from "../images/green_check.svg";
+import React from "react";
 
 const TodoItem = ({
   text,
@@ -115,4 +116,4 @@ const DetailBtn = styled.button`
   cursor: pointer;
 `;
 
-export default TodoItem;
+export default React.memo(TodoItem);

--- a/todo/src/components/TodoList.js
+++ b/todo/src/components/TodoList.js
@@ -1,7 +1,7 @@
 import TodoItem from "./TodoItem";
 import styled from "styled-components";
 import UpdateTodo from "./UpdateTodo";
-import { useState } from "react";
+import React, { useState } from "react";
 
 const TodoList = ({ todoList, setTodoList }) => {
   const [activeItem, setActiveItem] = useState(-1);
@@ -38,4 +38,4 @@ const TodoListBlock = styled.div`
   overflow-y: auto;
 `;
 
-export default TodoList;
+export default React.memo(TodoList);

--- a/todo/src/components/UpdateTodo.js
+++ b/todo/src/components/UpdateTodo.js
@@ -1,36 +1,13 @@
-import { useState } from "react";
+import React from "react";
 import styled from "styled-components";
 import { ReactComponent as CloseIcon } from "../images/close.svg";
+import useUpdateTodo from "../custom-hook/useUpdateTodo";
 
 function UpdateTodo({ id, setActiveItem, todoList, setTodoList }) {
-  const [editText, setEditText] = useState("");
+  const { editText, handleChange, handleSubmit, deleteTodo } = useUpdateTodo();
 
   const closeModal = () => {
     setActiveItem(-1);
-  };
-
-  const deleteTodo = () => {
-    setTodoList(todoList.filter((e) => e.id !== id));
-    closeModal();
-  };
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    if (editText) {
-      const newTodoList = todoList.map((item) => ({
-        ...item,
-        text: item.id === id ? editText : item.text,
-      }));
-      setTodoList(newTodoList);
-      closeModal();
-      setEditText("");
-    } else {
-      alert("수정할 내용을 입력해주세요!");
-    }
-  };
-
-  const handleChange = (e) => {
-    setEditText(e.target.value);
   };
 
   return (
@@ -42,7 +19,11 @@ function UpdateTodo({ id, setActiveItem, todoList, setTodoList }) {
         </Head>
         <h3>Current Todo : </h3>
         <CurrentTodo>{todoList.find((e) => e.id === id)?.text}</CurrentTodo>
-        <Form onSubmit={handleSubmit}>
+        <Form
+          onSubmit={(e) =>
+            handleSubmit(e, id, todoList, setTodoList, closeModal)
+          }
+        >
           <h3>Edit Todo :</h3>
           <Input
             placeholder="새로운 일정을 입력하세요."
@@ -50,7 +31,10 @@ function UpdateTodo({ id, setActiveItem, todoList, setTodoList }) {
             value={editText}
           ></Input>
           <BtnContainer>
-            <DeleteBtn onClick={deleteTodo} type="button">
+            <DeleteBtn
+              onClick={() => deleteTodo(id, todoList, setTodoList, closeModal)}
+              type="button"
+            >
               Delete Task
             </DeleteBtn>
             <SaveBtn>Save Changes</SaveBtn>
@@ -155,4 +139,4 @@ const Input = styled.input`
   outline: none;
 `;
 
-export default UpdateTodo;
+export default React.memo(UpdateTodo);

--- a/todo/src/custom-hook/useUpdateTodo.js
+++ b/todo/src/custom-hook/useUpdateTodo.js
@@ -1,0 +1,33 @@
+import { useState } from "react";
+
+function useUpdateTodo() {
+  const [editText, setEditText] = useState("");
+
+  const handleChange = (e) => {
+    setEditText(e.target.value);
+  };
+
+  const handleSubmit = (e, id, todoList, setTodoList, closeModal) => {
+    e.preventDefault();
+    if (editText) {
+      const newTodoList = todoList.map((item) => ({
+        ...item,
+        text: item.id === id ? editText : item.text,
+      }));
+      setTodoList(newTodoList);
+      closeModal();
+      setEditText("");
+    } else {
+      alert("수정할 내용을 입력해주세요!");
+    }
+  };
+
+  const deleteTodo = (id, todoList, setTodoList, closeModal) => {
+    setTodoList(todoList.filter((e) => e.id !== id));
+    closeModal();
+  };
+
+  return { editText, handleChange, handleSubmit, deleteTodo };
+}
+
+export default useUpdateTodo;


### PR DESCRIPTION
## 결과물 소개

React.memo와 useMemo 등을 활용해 투두리스트의 성능을 최적화하고 커스텀 훅을 만들었습니다.

<br>

## 상세 설명

### 기능 요구사항 체크

- [x] 부모 컴포넌트에 기능과 관계없는 임시 state(test) 생성
- [x] react-dev tools를 이용해 임시 state(test)가 업데이트 될 때 마다 리렌더링 되는 자식 컴포넌트 확인
- [x]  useMemo, React.memo를 활용해 불필요한 리렌더링 축소
- [x]  react-dev tools를 이용해 성능 개선 비교
- [x]  커스텀 훅(useUpdateTodo) 생성
- [x]  vercel을 활용해 웹사이트 배포

<br>

### 기능 설명
1. App.js에 `test`라는 이름의 임시 state를 생성했습니다. 
2. React.memo를 활용해 Head, NavBar, TodoBoard, TodoHead, TodoList, TodoItem, AddTodo, UpdateTodo 의 렌더링을 최적화하고자 했습니다.
3. useMemo를 활용해 NavBar에서 todoList 개수를 나타내는 부분을 최적화하고자 했습니다.
```javascript
 const counts = useMemo(
    () => ({
      1: todoList.filter((item) => item.priority === 1).length,
      2: todoList.filter((item) => item.priority === 2).length,
      3: todoList.filter((item) => item.priority === 3).length,
    }),
    [todoList]
  );
```
5. UpdateTodo 컴포넌트에 있던 handleChange, handleSubmit, deleteTodo를 커스텀 훅으로 분리했습니다.(`useUpdateTodo` 라는 이름으로 생성)
6. vercel을 이용해 웹사이트를 배포했습니다. 
- 주소 : https://efub3-frontend-assignment-2.vercel.app/

<br>

## 어려웠던 점
임시 state에 변화가 생길 때 불필요한 렌더링이 발생하는 것은 해결되었지만, 일정을 추가하거나 수정할 때(todoList가 갱신될 때) 관련 컴포넌트 내부에서 불필요한 요소들이 리렌더링되는 것을 해결하지는 못했습니다.(원래 같은 컴포넌트에 속해 있으면 무조건 다같이 렌더링이 발생할 수밖에 없는 것일까요..?)
특히, NavBar는 일정 개수를 나타내기 위해 todoList를 props로 받기 때문에 todoList에 변동이 일어나면 렌더링이 발생하는데, 갯수 부분만 렌더링 되고 다른 요소들은 렌더링 되지 않도록 하고 싶습니다. NavBar에서 todoList에 변동이 생길시 이와 관련없는 컴포넌트 내부 요소들이 렌더링되는 것을 막으려면 어떻게 해야하는지 조언주시면 감사하겠습니다!

<br>

## 결과물 사진
### 최적화 전

https://github.com/EFUB/efub3-frontend-assignment-2/assets/104717341/327822ae-211b-4bfb-aa66-57c202bea382

### 최적화 후

https://github.com/EFUB/efub3-frontend-assignment-2/assets/104717341/3db38c0c-f84f-4f02-b784-9061dc636600

