### PR TITLE
[조정민] 프론트 7주차 과제 제출

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # efub3-frontend-assignment-2
 
 💛 이펍 프론트엔드 5, 6, 7주차 과제 [React Todolist] 제출 레포지토리
+
+### vercel로 배포된 링크
+
+https://efub3-frontend-assignment-2-beryl.vercel.app/

--- a/src/components/TodoCreate.js
+++ b/src/components/TodoCreate.js
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { FaRegPlusSquare } from "react-icons/fa";
 import styled from "styled-components";
 
@@ -15,6 +15,7 @@ const TodoCreate = ({ todoList, setTodoList }) => {
   const handleChange = (e) => {
     setText(e.target.value);
   };
+  console.log("TodoCreate 렌더링");
   return (
     <Form onSubmit={addItem}>
       <Input

--- a/src/components/TodoCreate.js
+++ b/src/components/TodoCreate.js
@@ -15,7 +15,6 @@ const TodoCreate = ({ todoList, setTodoList }) => {
   const handleChange = (e) => {
     setText(e.target.value);
   };
-  console.log("TodoCreate 렌더링");
   return (
     <Form onSubmit={addItem}>
       <Input

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -31,6 +31,8 @@ const TodoItem = ({ todoList, setTodoList, id, text, done }) => {
       )
     );
   };
+  console.log("TodoItem 렌더링");
+
   return (
     <TodoItemContainer key={id}>
       {/* 완료 버튼 */}

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -1,28 +1,34 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import styled, { css } from "styled-components";
-import { FaPen, FaTrash, FaCheckSquare, FaRegSquare } from "react-icons/fa";
+import { FaPen, FaTrash } from "react-icons/fa";
+import ToggleButton from "./buttons/ToggleButton";
+import DeleteButton from "./buttons/DeleteButton";
+import ModifyButton from "./buttons/ModifyButton";
 
 const TodoItem = ({ todoList, setTodoList, id, text, done }) => {
   const [modifying, setModifying] = useState(false); //수정하는 중인지 여부
   //투두 완료 토글
-  const toggleItem = () => {
+  const toggleItem = useCallback(() => {
     setTodoList(
       todoList.map((item) => (item.id === id ? { ...item, done: !done } : item))
     );
-  };
+  }, [todoList]);
   //투두 삭제
-  const deleteItem = () => {
+  const deleteItem = useCallback(() => {
     setTodoList(
       todoList.filter((item) => {
         return item.id !== id;
       })
     );
-  };
+  }, [todoList]);
   //투두 수정 토글
-  const toggleModify = (e) => {
-    e.preventDefault();
-    setModifying((modifying) => !modifying);
-  };
+  const toggleModify = useCallback(
+    (e) => {
+      e.preventDefault();
+      setModifying((modifying) => !modifying);
+    },
+    [modifying]
+  );
   //투두 수정
   const modifyItem = (e) => {
     setTodoList(
@@ -36,13 +42,7 @@ const TodoItem = ({ todoList, setTodoList, id, text, done }) => {
   return (
     <TodoItemContainer key={id}>
       {/* 완료 버튼 */}
-      <Button onClick={toggleItem}>
-        {done ? (
-          <FaCheckSquare size={iconSize} />
-        ) : (
-          <FaRegSquare size={iconSize} />
-        )}
-      </Button>
+      <ToggleButton toggleItem={toggleItem} done={done} iconSize={iconSize} />
       {modifying ? (
         //수정 폼
         <form style={{ display: "inline" }} onSubmit={toggleModify}>
@@ -58,13 +58,9 @@ const TodoItem = ({ todoList, setTodoList, id, text, done }) => {
         <Text done={done}>{text}</Text>
       )}
       {/* 수정 버튼 */}
-      <Button onClick={toggleModify}>
-        <FaPen size={iconSize} />
-      </Button>
+      <ModifyButton toggleModify={toggleModify} iconSize={iconSize} />
       {/* 삭제 버튼 */}
-      <Button onClick={deleteItem}>
-        <FaTrash size={iconSize} />
-      </Button>
+      <DeleteButton deleteItem={deleteItem} iconSize={iconSize} />
     </TodoItemContainer>
   );
 };

--- a/src/components/TodoItem.js
+++ b/src/components/TodoItem.js
@@ -37,8 +37,6 @@ const TodoItem = ({ todoList, setTodoList, id, text, done }) => {
       )
     );
   };
-  console.log("TodoItem 렌더링");
-
   return (
     <TodoItemContainer key={id}>
       {/* 완료 버튼 */}

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -2,6 +2,7 @@ import TodoItem from "./TodoItem";
 import styled from "styled-components";
 
 const TodoList = ({ todoList, setTodoList }) => {
+  console.log("TodoList 렌더링");
   return (
     <TodoListContainer>
       {todoList.map((item) => {

--- a/src/components/TodoList.js
+++ b/src/components/TodoList.js
@@ -2,7 +2,6 @@ import TodoItem from "./TodoItem";
 import styled from "styled-components";
 
 const TodoList = ({ todoList, setTodoList }) => {
-  console.log("TodoList 렌더링");
   return (
     <TodoListContainer>
       {todoList.map((item) => {

--- a/src/components/TodoTitle.js
+++ b/src/components/TodoTitle.js
@@ -2,7 +2,6 @@ import React from "react";
 import styled from "styled-components";
 
 const TodoTitle = () => {
-  console.log("TodoTitle 렌더링");
   return <Text>Jamie's Todo</Text>;
 };
 

--- a/src/components/TodoTitle.js
+++ b/src/components/TodoTitle.js
@@ -1,0 +1,13 @@
+import React from "react";
+import styled from "styled-components";
+
+const TodoTitle = () => {
+  console.log("TodoTitle 렌더링");
+  return <Text>Jamie's Todo</Text>;
+};
+
+const Text = styled.div`
+  font-size: 50px;
+`;
+
+export default React.memo(TodoTitle);

--- a/src/components/buttons/DeleteButton.js
+++ b/src/components/buttons/DeleteButton.js
@@ -1,0 +1,14 @@
+import React from "react";
+import { FaTrash } from "react-icons/fa";
+import styled from "styled-components";
+import * as Styled from "./StyledButton";
+
+const DeleteButton = ({ deleteItem, iconSize }) => {
+  return (
+    <Styled.Button onClick={deleteItem}>
+      <FaTrash size={iconSize} />
+    </Styled.Button>
+  );
+};
+
+export default React.memo(DeleteButton);

--- a/src/components/buttons/ModifyButton.js
+++ b/src/components/buttons/ModifyButton.js
@@ -1,0 +1,14 @@
+import React from "react";
+import styled from "styled-components";
+import { FaPen } from "react-icons/fa";
+import * as Styled from "./StyledButton";
+
+const ModifyButton = ({ toggleModify, iconSize }) => {
+  return (
+    <Styled.Button onClick={toggleModify}>
+      <FaPen size={iconSize} />
+    </Styled.Button>
+  );
+};
+
+export default React.memo(ModifyButton);

--- a/src/components/buttons/StyledButton.js
+++ b/src/components/buttons/StyledButton.js
@@ -1,0 +1,10 @@
+import React from "react";
+import styled from "styled-components";
+
+export const Button = styled.button`
+  background-color: white;
+  border: none;
+  padding-top: 10px;
+  padding-left: 0;
+  padding-right: 0;
+`;

--- a/src/components/buttons/ToggleButton.js
+++ b/src/components/buttons/ToggleButton.js
@@ -1,0 +1,26 @@
+import React from "react";
+import styled from "styled-components";
+import { FaCheckSquare, FaRegSquare } from "react-icons/fa";
+import * as Styled from "./StyledButton";
+
+const ToggleButton = ({ toggleItem, done, iconSize }) => {
+  return (
+    <Styled.Button onClick={toggleItem}>
+      {done ? (
+        <FaCheckSquare size={iconSize} />
+      ) : (
+        <FaRegSquare size={iconSize} />
+      )}
+    </Styled.Button>
+  );
+};
+
+const Button = styled.button`
+  background-color: white;
+  border: none;
+  padding-top: 10px;
+  padding-left: 0;
+  padding-right: 0;
+`;
+
+export default React.memo(ToggleButton);

--- a/src/components/buttons/ToggleButton.js
+++ b/src/components/buttons/ToggleButton.js
@@ -15,12 +15,4 @@ const ToggleButton = ({ toggleItem, done, iconSize }) => {
   );
 };
 
-const Button = styled.button`
-  background-color: white;
-  border: none;
-  padding-top: 10px;
-  padding-left: 0;
-  padding-right: 0;
-`;
-
 export default React.memo(ToggleButton);

--- a/src/pages/Todo.js
+++ b/src/pages/Todo.js
@@ -12,7 +12,6 @@ function Todo() {
   useEffect(() => {
     localStorage.setItem("localTodoList", JSON.stringify(todoList));
   }, [todoList]);
-  console.log("Todo 렌더링");
   return (
     <RootContainer className="Todo">
       <Container>

--- a/src/pages/Todo.js
+++ b/src/pages/Todo.js
@@ -1,6 +1,7 @@
+import TodoTitle from "../components/TodoTitle";
 import TodoList from "../components/TodoList";
 import TodoCreate from "../components/TodoCreate";
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 
 function Todo() {
@@ -11,10 +12,11 @@ function Todo() {
   useEffect(() => {
     localStorage.setItem("localTodoList", JSON.stringify(todoList));
   }, [todoList]);
+  console.log("Todo 렌더링");
   return (
     <RootContainer className="Todo">
       <Container>
-        <Text>Jamie's Todo</Text>
+        <TodoTitle />
         <TodoCreate todoList={todoList} setTodoList={setTodoList} />
         <TodoList todoList={todoList} setTodoList={setTodoList} />
       </Container>
@@ -36,10 +38,6 @@ const Container = styled.div`
   margin-top: 70px;
   border: 1px grey solid;
   border-radius: 30px;
-`;
-
-const Text = styled.div`
-  font-size: 50px;
 `;
 
 export default Todo;


### PR DESCRIPTION
# 🍋 결과물 소개
투두리스트 요소들의 재렌더링을 방지했습니다.
<br/>

# 🍋 상세 설명
- 투두리스트 상단의 Jamie's Todo라고 적혀있는 부분은 어느 state에도 의존하지 않기 때문에 따로 TodoTitle 컴포넌트로 작성한 뒤 React.memo(TodoTitle)을 통해 재렌더링을 막았습니다.

- TodoItem에서 토글버튼, 수정버튼, 삭제버튼의 불필요한 재렌더링을 막았습니다. 세 버튼을 components/buttons 폴더 안에 각각 ToggleButton, ModifyButton, DeleteButton 컴포넌트로 작성한 뒤 React.memo를 사용했습니다. 또한 버튼들에 props로 전달되는 함수들 또한 useCallback을 통해 재생성을 막았습니다.

- 하나의 투두 변경될 때 모든 투두가 재렌더링 되는 것을 막는 것은 아직 구현하지 못했습니다. 좀 더 고민해 볼 예정입니다.
<br/>


# 🍋 결과물 사진
![KakaoTalk_20230514_172307204](https://github.com/EFUB/efub3-frontend-assignment-2/assets/97157930/d0b863d7-196a-4277-8c57-5e186db3936f)

chores라는 새로운 투두를 생성했을 때, 상단의 Jamie's Todo가 재렌더링 되지 않는 것을 볼 수 있습니다.
<br/><br/>

![KakaoTalk_20230514_172359109](https://github.com/EFUB/efub3-frontend-assignment-2/assets/97157930/f89dc589-a16e-468d-be72-33ecf45eb206)

assignment라는 투두의 토글버튼을 눌렀을 때, 우측의 수정버튼은 재렌더링 되지 않는 것을 볼 수 있습니다.
<br/><br/>

![KakaoTalk_20230514_172345675](https://github.com/EFUB/efub3-frontend-assignment-2/assets/97157930/3169c3ff-5492-4f8e-af31-3835e7cc91df)

수정버튼을 눌렀을 때, 좌측의 토글버튼과 우측의 삭제버튼은 재렌더링 되지 않는 것을 볼 수 있습니다.
<br/><br/>


# 🍋 배포 url
https://efub3-frontend-assignment-2-beryl.vercel.app/
<br/><br/>
